### PR TITLE
EC-CUBE3系を動作させるためにmod_rewriteを有効化

### DIFF
--- a/5.4/Dockerfile
+++ b/5.4/Dockerfile
@@ -9,7 +9,7 @@ RUN apt-get update && apt-get install --no-install-recommends -y \
         && docker-php-ext-install \
         mbstring zip gd xml pdo pdo_pgsql pdo_mysql soap mcrypt intl \
         && rm -r /var/lib/apt/lists/*
-
+RUN a2enmod rewrite
 RUN curl -sS https://getcomposer.org/installer | php -- \
         --filename=composer \
         --install-dir=/usr/local/bin

--- a/5.5/Dockerfile
+++ b/5.5/Dockerfile
@@ -9,7 +9,7 @@ RUN apt-get update && apt-get install --no-install-recommends -y \
         && docker-php-ext-install -j$(nproc) \
         mbstring zip gd xml pdo pdo_pgsql pdo_mysql soap mcrypt intl \
         && rm -r /var/lib/apt/lists/*
-
+RUN a2enmod rewrite
 RUN curl -sS https://getcomposer.org/installer | php -- \
         --filename=composer \
         --install-dir=/usr/local/bin

--- a/5.6/Dockerfile
+++ b/5.6/Dockerfile
@@ -9,7 +9,7 @@ RUN apt-get update && apt-get install --no-install-recommends -y \
         && docker-php-ext-install -j$(nproc) \
         mbstring zip gd xml pdo pdo_pgsql pdo_mysql soap mcrypt intl \
         && rm -r /var/lib/apt/lists/*
-
+RUN a2enmod rewrite
 RUN curl -sS https://getcomposer.org/installer | php -- \
         --filename=composer \
         --install-dir=/usr/local/bin

--- a/7.0/Dockerfile
+++ b/7.0/Dockerfile
@@ -9,7 +9,7 @@ RUN apt-get update && apt-get install --no-install-recommends -y \
         && docker-php-ext-install -j$(nproc) \
         mbstring zip gd xml pdo pdo_pgsql pdo_mysql soap mcrypt intl \
         && rm -r /var/lib/apt/lists/*
-
+RUN a2enmod rewrite
 RUN curl -sS https://getcomposer.org/installer | php -- \
         --filename=composer \
         --install-dir=/usr/local/bin

--- a/7.1/Dockerfile
+++ b/7.1/Dockerfile
@@ -9,7 +9,7 @@ RUN apt-get update && apt-get install --no-install-recommends -y \
         && docker-php-ext-install -j$(nproc) \
         mbstring zip gd xml pdo pdo_pgsql pdo_mysql soap mcrypt intl \
         && rm -r /var/lib/apt/lists/*
-
+RUN a2enmod rewrite
 RUN curl -sS https://getcomposer.org/installer | php -- \
         --filename=composer \
         --install-dir=/usr/local/bin


### PR DESCRIPTION
EC-CUBE3系を動作させるためにmod_rewirteを有効化します。