### PR TITLE
latestを7.3に変更

### DIFF
--- a/5.6/Dockerfile
+++ b/5.6/Dockerfile
@@ -2,8 +2,9 @@ FROM php:5.6-apache
 
 MAINTAINER Kentaro Ohkouchi <nanasess@fsm.ne.jp>
 
-RUN apt-get update && apt-get install --no-install-recommends -y \
-        git curl wget sudo libfreetype6-dev libjpeg62-turbo-dev libmcrypt-dev libmcrypt-dev libxml2-dev libpq-dev libpq5 postgresql-client mysql-client ssl-cert libicu-dev \
+RUN mkdir -p /usr/share/man/man1 && mkdir -p /usr/share/man/man7 && \
+        apt-get update && apt-get install --no-install-recommends -y \
+        git curl wget sudo libfreetype6-dev libjpeg62-turbo-dev libmcrypt-dev libmcrypt-dev libxml2-dev libpq-dev libpq5 postgresql-client default-mysql-client ssl-cert libicu-dev \
         && docker-php-ext-configure \
         gd --with-freetype-dir=/usr/include/ --with-jpeg-dir=/usr/include/ \
         && docker-php-ext-install -j$(nproc) \

--- a/7.0/Dockerfile
+++ b/7.0/Dockerfile
@@ -2,8 +2,9 @@ FROM php:7.0-apache
 
 MAINTAINER Kentaro Ohkouchi <nanasess@fsm.ne.jp>
 
-RUN apt-get update && apt-get install --no-install-recommends -y \
-        git curl wget sudo libfreetype6-dev libjpeg62-turbo-dev libmcrypt-dev libmcrypt-dev libxml2-dev libpq-dev libpq5 postgresql-client mysql-client ssl-cert libicu-dev \
+RUN mkdir -p /usr/share/man/man1 && mkdir -p /usr/share/man/man7 && \
+        apt-get update && apt-get install --no-install-recommends -y \
+        git curl wget sudo libfreetype6-dev libjpeg62-turbo-dev libmcrypt-dev libmcrypt-dev libxml2-dev libpq-dev libpq5 postgresql-client default-mysql-client ssl-cert libicu-dev \
         && docker-php-ext-configure \
         gd --with-freetype-dir=/usr/include/ --with-jpeg-dir=/usr/include/ \
         && docker-php-ext-install -j$(nproc) \

--- a/7.1/Dockerfile
+++ b/7.1/Dockerfile
@@ -2,8 +2,9 @@ FROM php:7.1-apache
 
 MAINTAINER Kentaro Ohkouchi <nanasess@fsm.ne.jp>
 
-RUN apt-get update && apt-get install --no-install-recommends -y \
-        git curl wget sudo libfreetype6-dev libjpeg62-turbo-dev libmcrypt-dev libmcrypt-dev libxml2-dev libpq-dev libpq5 postgresql-client mysql-client ssl-cert libicu-dev \
+RUN mkdir -p /usr/share/man/man1 && mkdir -p /usr/share/man/man7 && \
+        apt-get update && apt-get install --no-install-recommends -y \
+        git curl wget sudo libfreetype6-dev libjpeg62-turbo-dev libmcrypt-dev libmcrypt-dev libxml2-dev libpq-dev libpq5 postgresql-client default-mysql-client ssl-cert libicu-dev \
         && docker-php-ext-configure \
         gd --with-freetype-dir=/usr/include/ --with-jpeg-dir=/usr/include/ \
         && docker-php-ext-install -j$(nproc) \

--- a/7.2/Dockerfile
+++ b/7.2/Dockerfile
@@ -2,9 +2,9 @@ FROM php:7.2-apache
 
 MAINTAINER Kentaro Ohkouchi <nanasess@fsm.ne.jp>
 
-RUN mkdir -p /usr/share/man/man1 /usr/share/man/man7
-RUN apt-get update && apt-get install --no-install-recommends -y \
-        git curl wget sudo libfreetype6-dev libjpeg62-turbo-dev libmcrypt-dev libmcrypt-dev libxml2-dev libpq-dev libpq5 postgresql-client mysql-client ssl-cert libicu-dev \
+RUN mkdir -p /usr/share/man/man1 /usr/share/man/man7 && \
+        apt-get update && apt-get install --no-install-recommends -y \
+        git curl wget sudo libfreetype6-dev libjpeg62-turbo-dev libmcrypt-dev libmcrypt-dev libxml2-dev libpq-dev libpq5 postgresql-client default-mysql-client ssl-cert libicu-dev \
         && docker-php-ext-configure \
         gd --with-freetype-dir=/usr/include/ --with-jpeg-dir=/usr/include/ \
         && docker-php-ext-install -j$(nproc) \

--- a/7.3/Dockerfile
+++ b/7.3/Dockerfile
@@ -5,6 +5,7 @@ MAINTAINER Kentaro Ohkouchi <nanasess@fsm.ne.jp>
 RUN mkdir -p /usr/share/man/man1 /usr/share/man/man7
 RUN apt-get update && apt-get install --no-install-recommends -y \
             curl \
+            default-mysql-client \
             git \
             libfreetype6-dev \
             libicu-dev \
@@ -14,7 +15,6 @@ RUN apt-get update && apt-get install --no-install-recommends -y \
             libpq5 \
             libxml2-dev \
             libzip-dev \
-            mysql-client \
             postgresql-client \
             ssl-cert \
             sudo \

--- a/README.md
+++ b/README.md
@@ -2,7 +2,8 @@ Docker image for php:*-apache with additional to PHP extensions
 ===============================================================
 
 ## Supported tags and respective Dockerfile links
-- `7.2`, `latest` [(7.2/Dockerfile)](https://github.com/EC-CUBE/php-ext-apache/blob/master/7.2/Dockerfile)
+- `7.3`, `latest` [(7.3/Dockerfile)](https://github.com/EC-CUBE/php-ext-apache/blob/master/7.3/Dockerfile)
+- `7.2` [(7.2/Dockerfile)](https://github.com/EC-CUBE/php-ext-apache/blob/master/7.2/Dockerfile)
 - `7.1` [(7.1/Dockerfile)](https://github.com/EC-CUBE/php-ext-apache/blob/master/7.1/Dockerfile)
 - `7.0` [(7.0/Dockerfile)](https://github.com/EC-CUBE/php-ext-apache/blob/master/7.0/Dockerfile)
 - `5.6` [(5.6/Dockerfile)](https://github.com/EC-CUBE/php-ext-apache/blob/master/5.6/Dockerfile)


### PR DESCRIPTION
- `latest` を `7.2` -> `7.3`
  - このPRではドキュメントだけ変更。Docker Hubの方でビルド設定は変更済み。
- `5.6` - `7.3` がビルドできなくなっていたのでついでに修正しました。
  - https://hub.docker.com/r/eccube/php-ext-apache/builds